### PR TITLE
Improve error handling and code formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,10 @@ fn main() -> Result<(), Error> {
         }
         let (updates, stdout) = get_updates();
         if updates > 0 {
-            let tooltip = stdout.trim_end().replace("\"", "\\\"").replace("\n", "\\n");
+            let tooltip = stdout.trim_end().replace('"', "\\\"").replace('\n', "\\n");
             println!("{{\"text\":\"{}\",\"tooltip\":\"{}\",\"class\":\"has-updates\",\"alt\":\"has-updates\"}}", updates, tooltip);
         } else {
-            println!("{{\"text\":{},\"tooltip\":\"System updated\",\"class\": \"updated\",\"alt\":\"updated\"}}", if clean_output {"\"\""} else {"\"0\""});
+            println!("{{\"text\":{},\"tooltip\":\"System updated\",\"class\":\"updated\",\"alt\":\"updated\"}}", if clean_output {"\"\""} else {"\"0\""});
         }
         iter += 1;
         std::thread::sleep(sleep_duration);
@@ -83,11 +83,11 @@ fn get_updates() -> (u16, String) {
     return match output.status.code() {
         Some(_code) => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            if stdout == "" {
-                return (0, "0".to_string());
+            if stdout.is_empty() {
+                return (0, '0'.to_string());
             }
             return ((stdout.split(" -> ").count() as u16) - 1, stdout);
         }
-        None => (0, "0".to_string()),
+        None => (0, '0'.to_string()),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,10 +84,10 @@ fn get_updates() -> (u16, String) {
         Some(_code) => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             if stdout.is_empty() {
-                return (0, '0'.to_string());
+                return (0, '0'.into());
             }
             return ((stdout.split(" -> ").count() as u16) - 1, stdout);
         }
-        None => (0, '0'.to_string()),
+        None => (0, '0'.into()),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,13 @@ fn main() -> Result<(), Error> {
                 display_help();
                 return Ok(());
             } else if arg == "--interval-seconds" && i + 1 < args.len() {
-                interval_seconds = args[i + 1].parse().unwrap();
+                interval_seconds = args[i + 1].parse().unwrap_or_else(|_|{
+                    panic!("--interval-seconds must be greater than 0!")
+                });
             } else if arg == "--network-interval-seconds" && i + 1 < args.len() {
-                network_interval_seconds = args[i + 1].parse().unwrap();
+                network_interval_seconds = args[i + 1].parse().unwrap_or_else(|_| {
+                    panic!("--network-interval-seconds must be greater than 0!")
+                });
             } else if arg == "--no-zero-output" {
                 clean_output = true;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,13 +33,13 @@ fn main() -> Result<(), Error> {
                 display_help();
                 return Ok(());
             } else if arg == "--interval-seconds" && i + 1 < args.len() {
-                interval_seconds = args[i + 1].parse().unwrap_or_else(|_|{
-                    panic!("--interval-seconds must be greater than 0!")
-                });
+                interval_seconds = args[i + 1]
+                    .parse()
+                    .unwrap_or_else(|_| panic!("--interval-seconds must be greater than 0!"));
             } else if arg == "--network-interval-seconds" && i + 1 < args.len() {
-                network_interval_seconds = args[i + 1].parse().unwrap_or_else(|_| {
-                    panic!("--network-interval-seconds must be greater than 0!")
-                });
+                network_interval_seconds = args[i + 1]
+                    .parse()
+                    .unwrap_or_else(|_| panic!("--network-interval-seconds must be greater than 0!"));
             } else if arg == "--no-zero-output" {
                 clean_output = true;
             }


### PR DESCRIPTION
- Handle ParseIntError on-the-spot during argument parsing. Use unwrap_or_else instead of unwrap().
- Use into() instead of to_string() on &str values in get_updates()