### PR TITLE
Add --hide-aur flag to not display AUR updates available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn display_help() {
     println!(
         "  --no-zero-output               Don't print '0' when there are no updates available"
     );
+    println!("  --hide-aur                      Don't print available AUR updates");
     println!("  --tooltip-align-columns <font> Format tooltip as a table using given font (default: monospace)");
     println!("  --color-semver-updates <colors> Check the difference of semantic versions and color them using the given colors.");
     println!("                                  The order of pango markup hex colors for colored updates is Major, Minor, Patch, Pre, Other.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() -> Result<(), Error> {
     let mut interval_seconds: u32 = 5;
     let mut network_interval_seconds: u32 = 300;
     let mut clean_output = false;
+    let mut hide_aur = false;
     let mut tooltip_align = false;
     let mut tooltip_font = "monospace";
     let mut color_semver_updates = false;
@@ -69,6 +70,8 @@ fn main() -> Result<(), Error> {
                 });
             } else if arg == "--no-zero-output" {
                 clean_output = true;
+            } else if arg == "--hide-aur" {
+                hide_aur = true;
             } else if arg == "--tooltip-align-columns" {
                 tooltip_align = true;
                 if i + 1 < args.len() && args[i + 1][..1] != *"-" {
@@ -101,10 +104,10 @@ fn main() -> Result<(), Error> {
         }
         let (pacman_updates, pacman_stdout) = get_updates();
         let (aur_updates, aur_stdout) = get_aur_updates();
-        let updates = pacman_updates + aur_updates;
-        let mut stdout = if !aur_stdout.is_empty() && !pacman_stdout.is_empty() {
+        let updates = pacman_updates + if !hide_aur { aur_updates } else { 0 };
+        let mut stdout = if !hide_aur && !aur_stdout.is_empty() && !pacman_stdout.is_empty() {
             format!("{}\n{}", pacman_stdout, aur_stdout)
-        } else if !aur_stdout.is_empty() {
+        } else if !hide_aur && !aur_stdout.is_empty() {
             aur_stdout
         } else {
             pacman_stdout


### PR DESCRIPTION
This is mainly useful if you have some AUR packages that work right now but will break if you update them.
Or if you have `-git` packages.

Sorry if the code isn't optimal, i'm not really a rust developer :')