### PR TITLE
Automatically switch to correct rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85"


### PR DESCRIPTION
Here's the issue: i have a bunch of rust apps from AUR, and NONE of them specify the correct rust toolchain to build them, and NONE of them have overlapping rust toolchain versions, so i've had to manually switch it ever single time.
this project in particular uses alpm which wants `edition2024`

now it switches automatically. might want to adjust the version, though. i just picked the first release that had edition2024 marked as stable.

it could also be changed to `stable` `beta` or `nightly` if that would fit better